### PR TITLE
Retarged CSS to account for editorial experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Feel free to fork it and use it however you like!
 
 ## Changelog
 
+### August 19, 2024 - v1.0.1
+
+Update CSS to account for editing experience: remove hiding/showing of elements by targeting `:not(.has-child-selected)`.
+
 ### July 18, 2024 - v1.0.0
 
 Initial launch.

--- a/assets/styles/core-blocks/cover-card--interactive.css
+++ b/assets/styles/core-blocks/cover-card--interactive.css
@@ -11,7 +11,7 @@
 	position: static;
 }
 /* Make whole card clickable */
-.is-style-card--interactive :where(.wp-block-heading) a:after {
+.is-style-card--interactive:not(.has-child-selected) :where(.wp-block-heading) a:after {
 	content: "";
 	inset: 0;
 	position: absolute;
@@ -23,8 +23,8 @@
 	transform: scale(1);
 	transition: all 0.35s ease;
 }
-.is-style-card--interactive:focus-within :where(.wp-block-cover__image-background),
-.is-style-card--interactive:hover :where(.wp-block-cover__image-background) {
+.is-style-card--interactive:not(.has-child-selected):focus-within :where(.wp-block-cover__image-background),
+.is-style-card--interactive:not(.has-child-selected):hover :where(.wp-block-cover__image-background) {
 	filter: saturate(200%) brightness(40%);
 	transform: scale(1.15);
 }
@@ -42,7 +42,7 @@
 	transform: scale(1) translateX(0);
 }
 /* Animate content area */
-.is-style-card--interactive :where(.is-vertical) .wp-block-group:first-of-type + .wp-block-group p {
+.is-style-card--interactive:not(.has-child-selected) :where(.is-vertical) .wp-block-group:first-of-type + .wp-block-group p {
 	max-height: 0;
 	opacity: 0;
 	overflow: hidden;

--- a/hover-reveal-card.php
+++ b/hover-reveal-card.php
@@ -4,7 +4,7 @@
 * Description: Extends the Cover block for an animating card effect.
 * Requires at least: 6.6
 * Requires PHP: 8.0
-* Version: 1.0.0
+* Version: 1.0.1
 * Author: Damon Cook
 * License: GPL-2.0-or-later
 * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -14,7 +14,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-
 
 /**
  * Enqueues the block styles for the plugin.


### PR DESCRIPTION
See: https://developer.wordpress.org/news/2024/07/30/building-a-card-layout-with-a-hover-reveal-effect/#comment-8720

Some of the existing CSS was affecting the editorial experience for users when trying to edit the nested content. By targeting the `:not(.has-child-selected)` we can apply editor-only exclusions and address this issue.